### PR TITLE
feat: Add RunPod Serverless support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,35 @@
+# Stage 1: Build the rembg package wheel
+FROM python:3.10-slim as builder
+
+WORKDIR /src
+
+# Copy all the source code
+COPY . .
+
+# Install build dependencies and build the wheel
+RUN pip install wheel
+RUN python setup.py bdist_wheel
+
+# Stage 2: Create the final, clean image
 FROM python:3.10-slim
 
 WORKDIR /app
 
 RUN pip install --upgrade pip
 
-COPY . .
-
+# Copy and install the Python dependencies
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install .
 
+# Copy the built wheel from the builder stage and install it
+COPY --from=builder /src/dist/*.whl .
+RUN pip install *.whl && rm *.whl
+
+# Now that rembg is installed, copy the handler
+COPY handler.py .
+
+# Download the necessary model files using the 'rembg' command
 RUN rembg d u2net
 
+# Set the command to run our handler
 CMD ["python", "handler.py"]


### PR DESCRIPTION
This commit adds the necessary files and configurations to deploy the rembg model on RunPod Serverless.

- A `handler.py` file is created to handle serverless requests, accepting an image URL as input.
- A `Dockerfile` is updated to build a container image suitable for RunPod. This version uses a multi-stage build to ensure all files are correctly placed and to create a smaller final image.
- A `requirements.txt` file is added to manage Python dependencies.
- A `runpod.toml` file is included for serverless deployment configuration.
- A `builder.sh` script is provided to facilitate building and pushing the Docker image.